### PR TITLE
Lenvan's AI ignore healing

### DIFF
--- a/scenarios/04_Temple_in_the_Deep.cfg
+++ b/scenarios/04_Temple_in_the_Deep.cfg
@@ -62,18 +62,6 @@
         [/status]
         [modifications]
             {TRAIT_WEAK}
-            [object]
-                [effect]
-                    apply_to=movement_costs
-                    replace=yes
-                    [movement_costs]
-                        flat=999
-                        shallow_water=999
-                        village=999
-                        frozen=999
-                    [/movement_costs]
-                [/effect]
-            [/object]
         [/modifications]
         {GOLD 200 250 300}
         {INCOME 3 8 13}
@@ -195,6 +183,11 @@
 
     [event]
         name=start
+        [modify_ai] 
+            id=Lich-Lord Lenvan
+            action=delete
+            path=stage[main_loop].candidate_action[healing]
+        [/modify_ai]
         [message]
             speaker=Lich-Lord Lenvan
             message= _ "Free! I’m free at last! No mere magi could seal me in here forever! Rise, my soldiers of darkness, the world will be ours once more!"


### PR DESCRIPTION
With this change, Lenvan can now move outside his castle and occupy villages to attack from them, but he won't aimlessly stay there in hopes of receiving any healing.